### PR TITLE
Fixed compiler warnings

### DIFF
--- a/Source/AGWindowView.m
+++ b/Source/AGWindowView.m
@@ -261,7 +261,7 @@ static NSMutableArray *_activeWindowViews;
 {
     if(view.superview == nil)
     {
-        [NSException raise:NSInternalInconsistencyException format:@"When calling %s we are expecting the view to be moved is already in a view hirearchy.", __PRETTY_FUNCTION__];
+        [NSException raise:NSInternalInconsistencyException format:@"When calling %s we are expecting the view to be moved is already in a view hierarchy.", __PRETTY_FUNCTION__];
     }
     
     view.frame = [view convertRect:view.bounds toView:self];


### PR DESCRIPTION
Hi Håvard,

I fixed some compiler warnings that appear when building AGWindowView with -Wall. To reproduce:
- Use the Xcode project that comes with AGWindowView
- Add "-Wall" to Other Warning Flags (Targets > Build Settings > WARNING_CFLAGS)
- Compiler emits warnings "Pragma diagnostic pop could not pop, no matching push"

Please consider my changes for merging into your repo. Thanks for this project.

-Claus
