### PR TITLE
Added AGHitTestDelegate to be able to override hitTest: method and pass touches to views below

### DIFF
--- a/Source/AGWindowView.h
+++ b/Source/AGWindowView.h
@@ -26,6 +26,17 @@
 #import "AGWindowViewDefines.h"
 
 /**
+ *  @protocol AGHitTestDelegate
+ *  @description Delegate which can respond to hitTest: method cought by AGWindowView. If not set super corresponding method is called.
+ */
+@protocol AGHitTestDelegate <NSObject>
+
+@optional
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event;
+
+@end
+
+/**
  * @class AGWindowView
  * @description A view which is added to a UIWindow. It will automatically fill window and rotate along with statusbar rotations.
  */
@@ -33,6 +44,11 @@
 @interface AGWindowView : UIView
 
 @property (nonatomic, assign) AGInterfaceOrientationMask supportedInterfaceOrientations;
+
+/**
+ *  @property id<AGHitTestDelegate> hitTestDelegate. Allows programmer to pass touches to views below.
+ */
+@property (nonatomic, weak) id<AGHitTestDelegate> hitTestDelegate;
 
 /**
  * @property UIViewController *controller. Convinience for having a strong reference to your controller.

--- a/Source/AGWindowView.m
+++ b/Source/AGWindowView.m
@@ -364,6 +364,18 @@ static BOOL IS_BELOW_IOS_7()
     return index == subviewsOnSuperview.count - 1;
 }
 
+#pragma mark - hitTest: method passing to delegate 
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    if (_hitTestDelegate) {
+        return [_hitTestDelegate hitTest:point withEvent:event];
+    }
+    else
+    {
+        return [super hitTest:point withEvent:event];
+    }
+}
+
 #pragma mark - Convenience methods
 
 + (NSArray *)allActiveWindowViews


### PR DESCRIPTION
Now I can display transparent fullscreen UIView with smaller UIView that covers e.g. only tab bar or navigation bar and touches are passed to subviews.
